### PR TITLE
feat(Toast): настройка дефолтных пропсов и динамических стилей для Уведомлений

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta name="color-scheme" content="dark light"> 
     <link rel="stylesheet" href="./src/styles/fonts/inter.css">
     <link rel="stylesheet" href="./src/styles/variables.css">
+    <link rel="stylesheet" href="./src/styles/style.css">
     <link rel="stylesheet" href="./src/styles/globals.css">
     <link rel="stylesheet" href="./src/styles/dark.css">
     <link rel="stylesheet" href="./src/styles/light.css"> 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="color-scheme" content="dark light"> 
     <link rel="stylesheet" href="./src/styles/fonts/inter.css">
     <link rel="stylesheet" href="./src/styles/variables.css">
-    <link rel="stylesheet" href="./src/styles/style.css">
+    <link rel="stylesheet" href="./src/styles/globals.css">
     <link rel="stylesheet" href="./src/styles/dark.css">
     <link rel="stylesheet" href="./src/styles/light.css"> 
   </head>

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,3 +1,9 @@
+:root{
+  --toast-border-radius: 3px;
+  --toast-green-color: var(--light-green-color);
+  --toast-red-color: var(--light-red-color);
+}
+
 .toast {
   position: relative;
   display: flex;

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,0 +1,62 @@
+.toast {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  margin: 12px;
+  border-radius: var(--toast-border-radius) 0 0 var(--toast-border-radius);
+  max-width: clamp(360px, 100%, 400px);
+  min-width: 240px;
+  width: fit-content;
+}
+
+.green {
+  background-color: var(--toast-background-green-color);
+}
+
+.red {
+  background-color: var(--toast-background-red-color);
+}
+
+.toast::after {
+  content: "";
+  position: absolute;
+  border-radius: var(--toast-border-radius) 0 0 var(--toast-border-radius);
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+}
+
+.green::after {
+  background-color: var(--toast-green-color);
+}
+
+.red::after {
+  background-color: var(--toast-red-color);
+}
+
+h5 {
+  font-size: var(--H5);
+  color: var(--text-color);
+}
+
+p {
+  font-size: var(--p);
+  color: var(--text-color);
+}
+
+a {
+  text-decoration: none;
+  font-weight: 700;
+  font-size: var(--p);
+}
+
+.green a {
+  color: var(--toast-green-color);
+}
+
+.red a {
+  color: var(--toast-red-color);
+}

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -8,15 +8,22 @@
   border-radius: var(--toast-border-radius) 0 0 var(--toast-border-radius);
   max-width: clamp(360px, 100%, 400px);
   min-width: 240px;
+  min-height: 80px;
   width: fit-content;
 }
 
 .green {
-  background-color: var(--toast-background-green-color);
+  background: linear-gradient(
+      color-mix(in srgb, var(--toast-green-color) 5%, transparent),
+      color-mix(in srgb, var(--toast-green-color) 5%, transparent)
+  ), var(--sec-color);
 }
 
 .red {
-  background-color: var(--toast-background-red-color);
+  background: linear-gradient(
+      color-mix(in srgb, var(--toast-red-color) 5%, transparent),
+      color-mix(in srgb, var(--toast-red-color) 5%, transparent)
+  ), var(--sec-color);
 }
 
 .toast::after {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,14 +1,5 @@
 import styles from './Toast.module.css'
-
-interface ToastProps {
-  status?: boolean,
-  title?: string,
-  description?: string,
-  link?: {
-    title_link: string,
-    link: string},
-  onClose?: () => void
-}
+import type {ToastProps} from "@/types/toastTypes.ts";
 
 const Toast = ({
   status = true, 
@@ -20,7 +11,7 @@ const Toast = ({
       <div className={`${styles.toast} ${status ? styles.green : styles.red}`}>
         <h5>{title}</h5>
         <p>{description}</p>
-        {link && <a href={link.link}>{link.title_link}</a>}
+        {link && <a href={link.link} target="_blank" rel="noopener noreferrer">{link.title_link}</a>}
       </div>
   )
 }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,28 @@
+import styles from './Toast.module.css'
+
+interface ToastProps {
+  status?: boolean,
+  title?: string,
+  description?: string,
+  link?: {
+    title_link: string,
+    link: string},
+  onClose?: () => void
+}
+
+const Toast = ({
+  status = true, 
+  title = 'Уведомление',
+  description = 'Не задано описание уведомления',
+  link
+} : ToastProps) => {
+  return (
+      <div className={`${styles.toast} ${status ? styles.green : styles.red}`}>
+        <h5>{title}</h5>
+        <p>{description}</p>
+        {link && <a href={link.link}>{link.title_link}</a>}
+      </div>
+  )
+}
+
+export default Toast

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,0 +1,1 @@
+export { default as Toast } from './Toast.tsx';

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -4,9 +4,4 @@
   --primary-color: rgb(40, 190, 70);
   --sec-color: rgb(36, 36, 36);
   --outline-color: rgb(48, 48, 48);
-
-  --toast-green-color: #75FF9E;
-  --toast-background-green-color: #282f2a;
-  --toast-red-color: #ff4b4b;
-  --toast-background-red-color: #2f2626;
 }

--- a/src/styles/dark.css
+++ b/src/styles/dark.css
@@ -4,4 +4,9 @@
   --primary-color: rgb(40, 190, 70);
   --sec-color: rgb(36, 36, 36);
   --outline-color: rgb(48, 48, 48);
+
+  --toast-green-color: #75FF9E;
+  --toast-background-green-color: #282f2a;
+  --toast-red-color: #ff4b4b;
+  --toast-background-red-color: #2f2626;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,8 @@ h5,
 h6,
 p {
   margin: 0;
+  padding: 0;
+  font-family: Inter, serif;
 }
 
 ul {
@@ -28,7 +30,7 @@ picture {
 button,
 a {
   color: currentColor;
-  font-family: inherit;
+  font-family: Inter, serif;
   font-size: inherit;
   line-height: inherit;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 *::before,
 *::after {
   box-sizing: border-box;
+  font-family: Inter, serif;
 }
 
 h1,
@@ -13,7 +14,6 @@ h6,
 p {
   margin: 0;
   padding: 0;
-  font-family: Inter, serif;
 }
 
 ul {
@@ -30,7 +30,6 @@ picture {
 button,
 a {
   color: currentColor;
-  font-family: Inter, serif;
   font-size: inherit;
   line-height: inherit;
 }

--- a/src/styles/light.css
+++ b/src/styles/light.css
@@ -4,6 +4,11 @@
   --primary-color: rgb(40, 190, 70);
   --sec-color: rgb(255, 255, 255);
   --outline-color: rgb(224, 224, 224);
+
+  --toast-green-color: #75FF9E;
+  --toast-background-green-color: #e0ffe8;
+  --toast-red-color: #ff4b4b;
+  --toast-background-red-color: #ffdcdc;
 }
 
 
@@ -15,6 +20,11 @@
     --primary-color: rgb(40, 190, 70);
     --sec-color: rgb(255, 255, 255);
     --outline-color: rgb(224, 224, 224);
+
+    --toast-green-color: #75FF9E;
+    --toast-background-green-color: #e0ffe8;
+    --toast-red-color: #ff4b4b;
+    --toast-background-red-color: #ffdcdc;
   }
 
 }

--- a/src/styles/light.css
+++ b/src/styles/light.css
@@ -4,29 +4,17 @@
   --primary-color: rgb(40, 190, 70);
   --sec-color: rgb(255, 255, 255);
   --outline-color: rgb(224, 224, 224);
-
-  --toast-green-color: #75FF9E;
-  --toast-background-green-color: #e0ffe8;
-  --toast-red-color: #ff4b4b;
-  --toast-background-red-color: #ffdcdc;
 }
 
 
 @media (prefers-color-scheme: light) {
-
   :root {
     --bg-color: rgb(246, 245, 248);
     --text-color: rgb(15, 23, 42);
     --primary-color: rgb(40, 190, 70);
     --sec-color: rgb(255, 255, 255);
     --outline-color: rgb(224, 224, 224);
-
-    --toast-green-color: #75FF9E;
-    --toast-background-green-color: #e0ffe8;
-    --toast-red-color: #ff4b4b;
-    --toast-background-red-color: #ffdcdc;
   }
-
 }
 
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -14,8 +14,6 @@
   --H6: 16px;
   --p : 16px;
 
-  --toast-border-radius: 3px;
-
-  --toast-green-color: #75FF9E;
-  --toast-red-color: #FF4B4B;
+  --light-green-color: #75FF9E;
+  --light-red-color: #FF4B4B;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,8 +1,23 @@
 :root {
-  --accent-color: #ff0070;
-  --headline-color: #db00ff;
-  --quote-color: #000028;
-  --text-color: #F1B2CE;
-  --bg-color: #000028;
-  --sub-accent-color: var(--accent-color);
+  --bg-color: rgb(26, 26, 26);
+  --text-color: rgb(241, 245, 249);
+  --primary-color: rgb(40, 190, 70);
+  --sec-color: rgb(36, 36, 36);
+  --outline-color: rgb(48, 48, 48);
+
+  /* Для уведомлений */
+  --H1: 36px;
+  --H2: 30px;
+  --H3: 26px;
+  --H4: 24px;
+  --H5: 20px;
+  --H6: 16px;
+  --p : 16px;
+
+  --toast-border-radius: 3px;
+
+  --toast-green-color: #75FF9E;
+  --toast-background-green-color: #282f2a;
+  --toast-red-color: #ff4b4b;
+  --toast-background-red-color: #2f2626;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -17,7 +17,5 @@
   --toast-border-radius: 3px;
 
   --toast-green-color: #75FF9E;
-  --toast-background-green-color: #282f2a;
-  --toast-red-color: #ff4b4b;
-  --toast-background-red-color: #2f2626;
+  --toast-red-color: #FF4B4B;
 }

--- a/src/types/toastTypes.ts
+++ b/src/types/toastTypes.ts
@@ -1,0 +1,9 @@
+export interface ToastProps {
+  status?: boolean,
+  title?: string,
+  description?: string,
+  link?: {
+    title_link: string,
+    link: string},
+  onClose?: () => void
+}


### PR DESCRIPTION
Closes #4 
- Подключены глобальные стили
- Изменены некоторые стили
- Добавлены значения по умолчанию для заголовка, текста и статуса уведомления.
- Настроено переключение стилей (успех/ошибка) в зависимости от пропса `status`.
<img width="611" height="594" alt="image" src="https://github.com/user-attachments/assets/b0cc7343-74c0-44e2-b72d-67c43e141fbe" />
